### PR TITLE
Bug fixes to memo/WAN insertion for First PRFs and CWP amounts can be $0

### DIFF
--- a/services/dsrp-api/app/api/application/models/payment_document.py
+++ b/services/dsrp-api/app/api/application/models/payment_document.py
@@ -50,10 +50,18 @@ class PaymentDocument(AuditMixin, Base):
 
         def get_memo():
             well_authorization_numbers = []
-            for cwp in self.contracted_work_payments:
-                cw = self.application.find_contracted_work_by_id(cwp.work_id)
+
+            work_ids = []
+            if self.payment_document_code == 'FIRST_PRF':
+                approved_work = self.application.contracted_work('APPROVED', False)
+                work_ids = [aw['work_id'] for aw in approved_work]
+            else:
+                work_ids = [cwp.work_id for cwp in self.contracted_work_payments]
+
+            for work_id in work_ids:
+                cw = self.application.find_contracted_work_by_id(work_id)
                 if not cw:
-                    raise Exception(f'Work ID {cwp.work_id} does not exist on this application!')
+                    raise Exception(f'Work ID {work_id} does not exist on this application!')
                 well_authorization_numbers.append(cw['well_authorization_number'])
             return ', '.join(well_authorization_numbers)
 

--- a/services/dsrp-api/app/api/application/models/payment_document.py
+++ b/services/dsrp-api/app/api/application/models/payment_document.py
@@ -100,7 +100,7 @@ class PaymentDocument(AuditMixin, Base):
                             raise Exception(
                                 f'Work ID {work_id} interim payment has not been approved!')
                         amount = contracted_work_payment.interim_paid_amount
-                        if not amount:
+                        if amount is None:
                             raise Exception(
                                 f'Work ID {work_id} interim payment amount has not been set!')
                     else:
@@ -108,7 +108,7 @@ class PaymentDocument(AuditMixin, Base):
                             raise Exception(
                                 f'Work ID {work_id} final payment has not been approved!')
                         amount = contracted_work_payment.final_paid_amount
-                        if not amount:
+                        if amount is None:
                             raise Exception(
                                 f'Work ID {work_id} final payment amount has not been set!')
 


### PR DESCRIPTION
* Fixes an issue where CWP amounts of $0 could not be used in generating PRFs
* Fixes an issue where WANs/memo was not generated properly for First PRFs if the application had no CWPs